### PR TITLE
Enable build by other frameworks, like yocto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 obj-m := lsm9ds1_i2c.o lsm9ds1_ag_i2c.o lsm9ds1_ag.o lsm9ds1_m.o lsm9ds1_m_i2c.o
 # lsm9ds1_ag_buffer.o
 
-KERNEL_SRC := /lib/modules/$(shell uname -r)/build
+KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
 SRC := $(shell pwd)
 
 all:

--- a/lsm9ds1_ag.c
+++ b/lsm9ds1_ag.c
@@ -457,14 +457,14 @@ irqreturn_t lsm9ds1_ag_trigger_handler(int irq, void *p)
         s64 delta_ts = 16807;
         s64 ts;
 
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
 
         mutex_lock(&ldata->lock);
 
         ret = ldata->read_reg_8(indio_dev, LSM9DS1_REG_FIFO_SRC, &samples);
         samples = samples & LSM9DS1_AG_FSS;
-        printk(KERN_WARNING "%s:%d: samples = %i\n",
-               __FUNCTION__,__LINE__, samples);
+        dev_dbg(&indio_dev->dev, "%s:%d: samples = %i\n",
+	        __FUNCTION__,__LINE__, samples);
 
         if (ret < 0 || samples <= 0)
                 goto done;
@@ -485,7 +485,7 @@ done:
         iio_trigger_notify_done(indio_dev->trig);
         mutex_unlock(&ldata->lock);
  
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
         return IRQ_HANDLED;
 }
 
@@ -495,7 +495,7 @@ static int lsm9ds1_ag_buffer_preenable(struct iio_dev *indio_dev)
         int ret;
 
         
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
 
         mutex_lock(&ldata->lock);
 
@@ -514,7 +514,7 @@ static int lsm9ds1_ag_buffer_preenable(struct iio_dev *indio_dev)
 
         mutex_unlock(&ldata->lock);
 
-        printk(KERN_WARNING "%s:%d:end\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d:end\n",__FUNCTION__,__LINE__);
         return ret;
 }
 
@@ -522,10 +522,10 @@ static int lsm9ds1_ag_buffer_postdisable(struct iio_dev *indio_dev)
 {
         int ret;
 
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
         ret = lsm9ds1_mreset_bit_reg(indio_dev, LSM9DS1_REG_CTRL_REG9,
                 LSM9DS1_AG_FIFO_EN);
-        printk(KERN_WARNING "%s:%d: ret = %i\n",__FUNCTION__,__LINE__, ret);
+        dev_dbg(&indio_dev->dev, "%s:%d: ret = %i\n",__FUNCTION__,__LINE__, ret);
         return ret;
 }
 
@@ -569,7 +569,7 @@ int lsm9ds1_ag_probe(struct iio_dev *indio_dev, struct device *dev)
                 goto error_buffer_cleanup;
         }
 	indio_dev->modes |= INDIO_BUFFER_TRIGGERED;
-        printk(KERN_WARNING "%s:%d: %i\n",__FUNCTION__,__LINE__, ret);
+        dev_dbg(&indio_dev->dev, "%s:%d: %i\n",__FUNCTION__,__LINE__, ret);
 
 	ret = iio_device_register(indio_dev);
 	if (ret >= 0)

--- a/lsm9ds1_m.c
+++ b/lsm9ds1_m.c
@@ -206,7 +206,7 @@ irqreturn_t lsm9ds1_m_trigger_handler(int irq, void *p)
         int ret;
         u8 iio_buffer[ALIGN(LSM9DS1_M_DATA_SIZE, sizeof(s64)) + sizeof(s64)]; // 3 channels 16bits + ts(64bits) + padding
 
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
 
         mutex_lock(&ldata->lock);
 
@@ -220,7 +220,7 @@ done:
         iio_trigger_notify_done(indio_dev->trig);
         mutex_unlock(&ldata->lock);
  
-        printk(KERN_WARNING "%s:%d\n",__FUNCTION__,__LINE__);
+        dev_dbg(&indio_dev->dev, "%s:%d\n",__FUNCTION__,__LINE__);
         return IRQ_HANDLED;
 }
 
@@ -262,7 +262,7 @@ int lsm9ds1_m_probe(struct iio_dev *indio_dev, struct device *dev)
                 goto error_buffer_cleanup;
         }
 	indio_dev->modes |= INDIO_BUFFER_TRIGGERED;
-        printk(KERN_WARNING "%s:%d: %i\n",__FUNCTION__,__LINE__, ret);
+        dev_dbg(&indio_dev->dev, "%s:%d: %i\n",__FUNCTION__,__LINE__, ret);
 
 	ret = iio_device_register(indio_dev);
 	if (ret >= 0)


### PR DESCRIPTION
With a simple little bitbake recipe like :

[per@home yocto-rpi]$ more layers/meta-project-addons/recipes-kernel/kernel-modules/kernel-module-lsm9ds1_0.1.bb                                                               
DESCRIPTION = "LSM9DS1 IMU driver"
SECTION = "iio"
LICENSE = "GPLv2"
LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
PR = "r0"

inherit module

SRCREV = "e6eacf01d3400aacdae4be9bde45703167c1684a"
SRC_URI = "git://github.com/jsagfr/lsm9ds1.git;protocol=https"
SRC_URI[md5sum] = "797e3b8938abe86af7eff1f6a12c6fcf"

S = "${WORKDIR}/git"
[per@home yocto-rpi]$ 

and the little buildfix herein, your driver works nicely in a yocto built image.
I run this with a raspberrypi0-wifi and BerryGPS-IMU, http://ozzmaker.com/product/berrygps-imu

Only limited testing so far but I see the sensor data at least changing :)

Thanks!